### PR TITLE
Hot fix of film service in Client App

### DIFF
--- a/ClientApp/src/app/film.service.ts
+++ b/ClientApp/src/app/film.service.ts
@@ -33,7 +33,7 @@ export class FilmService {
       params: new HttpParams()
     };
     Object.keys(filter).forEach((key) => {
-      options.params.append(key, filter[key]);
+      options.params = options.params.set(key, filter[key]);
     });
     return this.http.get<Film[]>(this.filmsUrl, options);
   }


### PR DESCRIPTION
Fixed HttpParams logic.
Append method is used in other cases.
Also HttpParams object is immutable, so we have to reassign it while adding a new filter parameter.